### PR TITLE
Reference Donkeyfont Icons By Name

### DIFF
--- a/src/android/Library/src/MultiImageChooserActivity.java
+++ b/src/android/Library/src/MultiImageChooserActivity.java
@@ -42,7 +42,6 @@ import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Set;
 
-import com.synconset.FakeR;
 import com.zenput.mobile.R;
 
 import android.app.Activity;
@@ -92,9 +91,6 @@ public class MultiImageChooserActivity extends Activity implements OnItemClickLi
     public static final String WIDTH_KEY = "WIDTH";
     public static final String HEIGHT_KEY = "HEIGHT";
     public static final String QUALITY_KEY = "QUALITY";
-
-    private final String M_ICON_SELECTED = "\uE060";
-    private final String M_ICON_UNSELECTED = "\uE061";
 
     private Typeface mDonkeyFont = null;
 
@@ -426,12 +422,14 @@ public class MultiImageChooserActivity extends Activity implements OnItemClickLi
                 circlePaint.setTypeface(mDonkeyFont);
                 circlePaint.setColor(Color.WHITE);
                 circlePaint.setTextSize(size);
-                canvas.drawText("\uE06E", padding, padding+size, circlePaint);
-                canvas.drawText(M_ICON_SELECTED, padding, padding+size, iconPaint);
+
+
+                canvas.drawText(getString(R.string.icon_zp_v2_circle), padding, padding + size, circlePaint);
+                canvas.drawText(getString(R.string.icon_zp_v2_gallery_image_selected), padding, padding+size, iconPaint);
             } else {
                 iconPaint.setColor(Color.WHITE);
                 iconPaint.setAlpha(255);
-                canvas.drawText(M_ICON_UNSELECTED, padding, padding+size, iconPaint);
+                canvas.drawText(getString(R.string.icon_zp_v2_gallery_image_unselected), padding, padding+size, iconPaint);
             }
         }
     }

--- a/src/ios/ELCImagePicker/ELCAssetCell.m
+++ b/src/ios/ELCImagePicker/ELCAssetCell.m
@@ -7,6 +7,7 @@
 
 #import "ELCAssetCell.h"
 #import "ELCAsset.h"
+#import "Donkeyfont.h"
 
 @interface ELCAssetCell ()
 
@@ -155,13 +156,14 @@ static const unsigned int gRowMax = 4;
 }
 
 - (void)selectThumbnail:(UILabel*)checkLabel circleLabel:(UILabel*)circleLabel selected:(bool)selected {
-    checkLabel.text = selected ? @"\uE060" : @"\uE061";
+    NSLog(@"image selected icon: %@", ICON_ZP_V2_GALLERY_IMAGE_SELECTED);
+    checkLabel.text = selected ? ICON_ZP_V2_GALLERY_IMAGE_SELECTED : ICON_ZP_V2_GALLERY_IMAGE_UNSELECTED;
     checkLabel.textColor = selected ? [UIColor colorWithRed:22.0f / 255.0f
                                                       green:157 / 255.0f
                                                        blue:217.0f / 255.0f
                                                       alpha:1.0] : [UIColor whiteColor];
     
-    circleLabel.text = @"\uE06E";
+    circleLabel.text = ICON_ZP_V2_CIRCLE;
     circleLabel.textColor = [UIColor whiteColor];
     circleLabel.alpha = selected ? 1.0f : 0.0f;
 }


### PR DESCRIPTION
This references Donkeyfont icons by their CSS class names rather than their raw content codes, as provided by https://github.com/zenput/cordova-plugin-donkeyfont/pull/1.