### PR TITLE
Add Linting and Prepare For NPM Deployment (MOBILE-868)

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,0 +1,168 @@
+{
+    "extends": [
+        "eslint:recommended"
+    ],
+    "env": {
+        "browser": true,
+        "commonjs": true,
+        "es6": false,
+        "jquery": true
+    },
+    "parserOptions": {
+        "ecmaVersion": 5
+    },
+    "rules": {
+        "block-spacing": [
+            "error",
+            "always"
+        ],
+        "brace-style": [
+            "error",
+            "1tbs",
+            { "allowSingleLine": true }
+        ],
+        "comma-dangle": [
+            "error",
+            {
+                "arrays": "never",
+                "objects": "never",
+                "imports": "never",
+                "exports": "never",
+                "functions": "never"
+            }
+        ],
+        "comma-spacing": [
+            "error",
+            {
+                "before": false,
+                "after": true
+            }
+        ],
+        "curly": [
+            "error"
+        ],
+        "dot-notation": "error",
+        "eol-last": [
+            "error",
+            "always"
+        ],
+        "indent": [
+            "error",
+            4,
+            {
+                "SwitchCase": 1,
+                "ignoreComments": true
+            }
+        ],
+        "key-spacing": [
+            "error",
+            {
+                "beforeColon": false,
+                "afterColon": true,
+                "mode": "strict"
+            }
+        ],
+        "keyword-spacing": [
+            "error"
+        ],
+        "linebreak-style": [
+            "error",
+            "unix"
+        ],
+        "max-len": [
+            "error",
+            {
+                "code": 120,
+                "ignoreComments": true,
+                "ignoreTrailingComments": true,
+                "ignoreUrls": true,
+                "ignoreStrings": true,
+                "ignoreTemplateLiterals": true,
+                "ignoreRegExpLiterals": true
+            }
+        ],
+        "no-console": [
+            "error",
+            {
+                "allow": [
+                    "warn",
+                    "error"
+                ]
+            }
+        ],
+        "no-debugger": "error",
+        "no-dupe-args": "error",
+        "no-dupe-keys": "error",
+        "no-mixed-spaces-and-tabs": "error",
+        "no-multiple-empty-lines": [
+            "error",
+            { "max": 1 }
+        ],
+        "no-throw-literal": "error",
+        "no-trailing-spaces": "error",
+        "no-undef": [
+            "error",
+            { "typeof": true }
+        ],
+        "no-unreachable": "error",
+        "no-unused-expressions": [
+            "error",
+            {
+                "allowShortCircuit": true,
+                "allowTernary": true,
+                "allowTaggedTemplates": true
+            }
+        ],
+        "no-unused-vars": [
+            "error",
+            {
+                "vars": "all",
+                "args": "none",
+                "ignoreRestSiblings": false
+            }
+        ],
+        "no-useless-escape": "off",
+        "object-curly-spacing": [
+            "error",
+            "always"
+        ],
+        "quote-props": [
+            "error",
+            "as-needed"
+        ],
+        "quotes": [
+            "error",
+            "single"
+        ],
+        "semi": [
+            "error",
+            "always"
+        ],
+        "space-before-blocks": [
+            "error",
+            "always"
+        ],
+        "space-before-function-paren": [
+            "error",
+            "never"
+        ],
+        "space-infix-ops": [
+            "error",
+            { "int32Hint": true }
+        ],
+        "spaced-comment": [
+            "error",
+            "always"
+        ],
+        "use-isnan": "error",
+        "valid-typeof": [
+            "error",
+            { "requireStringLiterals": true }
+        ]
+    },
+    "globals": {
+        "cordova": false,
+        "Windows": false,
+        "WinJS": false
+    }
+}

--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,5 @@
 xcuserdata/
 project.xcworkspace/
 tags
+
+node_modules

--- a/README.md
+++ b/README.md
@@ -1,16 +1,12 @@
-cordova-imagePicker
-===================
-
 Cordova Plugin For Multiple Image Selection - implemented for iOS and Android 4.0 and above.
 
 ## Installing the plugin
 
-The plugin conforms to the Cordova plugin specification, it can be installed
-using the Cordova / Phonegap command line interface.
+The plugin conforms to the Cordova plugin specification, it can be installed using the Cordova / Phonegap command line interface.
 
-    phonegap plugin add cordova-plugin-image-picker
-
-    cordova plugin add cordova-plugin-image-picker
+```sh
+cordova plugin add @zenput/cordova-plugin-image-picker
+```
 
 
 ## Using the plugin

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,961 @@
+{
+  "name": "@zenput/cordova-plugin-image-picker",
+  "version": "1.2.3",
+  "lockfileVersion": 1,
+  "requires": true,
+  "dependencies": {
+    "@babel/code-frame": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.0.0.tgz",
+      "integrity": "sha512-OfC2uemaknXr87bdLUkWog7nYuliM9Ij5HUcajsVcMCpQrcLmtxRbVFTIqmcSkSeYRBFBRxs2FiUqFJDLdiebA==",
+      "dev": true,
+      "requires": {
+        "@babel/highlight": "^7.0.0"
+      }
+    },
+    "@babel/highlight": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.0.0.tgz",
+      "integrity": "sha512-UFMC4ZeFC48Tpvj7C8UgLvtkaUuovQX+5xNWrsIoMG8o2z+XFKjKaN9iVmS84dPwVN00W4wPmqvYoZF3EGAsfw==",
+      "dev": true,
+      "requires": {
+        "chalk": "^2.0.0",
+        "esutils": "^2.0.2",
+        "js-tokens": "^4.0.0"
+      }
+    },
+    "acorn": {
+      "version": "6.0.5",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-6.0.5.tgz",
+      "integrity": "sha512-i33Zgp3XWtmZBMNvCr4azvOFeWVw1Rk6p3hfi3LUDvIFraOMywb1kAtrbi+med14m4Xfpqm3zRZMT+c0FNE7kg==",
+      "dev": true
+    },
+    "acorn-jsx": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.0.1.tgz",
+      "integrity": "sha512-HJ7CfNHrfJLlNTzIEUTj43LNWGkqpRLxm3YjAlcD0ACydk9XynzYsCBHxut+iqt+1aBXkx9UP/w/ZqMr13XIzg==",
+      "dev": true
+    },
+    "ajv": {
+      "version": "6.7.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.7.0.tgz",
+      "integrity": "sha512-RZXPviBTtfmtka9n9sy1N5M5b82CbxWIR6HIis4s3WQTXDJamc/0gpCWNGz6EWdWp4DOfjzJfhz/AS9zVPjjWg==",
+      "dev": true,
+      "requires": {
+        "fast-deep-equal": "^2.0.1",
+        "fast-json-stable-stringify": "^2.0.0",
+        "json-schema-traverse": "^0.4.1",
+        "uri-js": "^4.2.2"
+      }
+    },
+    "ansi-escapes": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-3.1.0.tgz",
+      "integrity": "sha512-UgAb8H9D41AQnu/PbWlCofQVcnV4Gs2bBJi9eZPxfU/hgglFh3SMDMENRIqdr7H6XFnXdoknctFByVsCOotTVw==",
+      "dev": true
+    },
+    "ansi-regex": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
+      "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
+      "dev": true
+    },
+    "ansi-styles": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+      "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+      "dev": true,
+      "requires": {
+        "color-convert": "^1.9.0"
+      }
+    },
+    "argparse": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
+      "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
+      "dev": true,
+      "requires": {
+        "sprintf-js": "~1.0.2"
+      }
+    },
+    "astral-regex": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/astral-regex/-/astral-regex-1.0.0.tgz",
+      "integrity": "sha512-+Ryf6g3BKoRc7jfp7ad8tM4TtMiaWvbF/1/sQcZPkkS7ag3D5nMBCe2UfOTONtAkaG0tO0ij3C5Lwmf1EiyjHg==",
+      "dev": true
+    },
+    "balanced-match": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
+      "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
+      "dev": true
+    },
+    "brace-expansion": {
+      "version": "1.1.11",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
+      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "dev": true,
+      "requires": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "callsites": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.0.0.tgz",
+      "integrity": "sha512-tWnkwu9YEq2uzlBDI4RcLn8jrFvF9AOi8PxDNU3hZZjJcjkcRAq3vCI+vZcg1SuxISDYe86k9VZFwAxDiJGoAw==",
+      "dev": true
+    },
+    "chalk": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+      "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+      "dev": true,
+      "requires": {
+        "ansi-styles": "^3.2.1",
+        "escape-string-regexp": "^1.0.5",
+        "supports-color": "^5.3.0"
+      }
+    },
+    "chardet": {
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/chardet/-/chardet-0.7.0.tgz",
+      "integrity": "sha512-mT8iDcrh03qDGRRmoA2hmBJnxpllMR+0/0qlzjqZES6NdiWDcZkCNAk4rPFZ9Q85r27unkiNNg8ZOiwZXBHwcA==",
+      "dev": true
+    },
+    "circular-json": {
+      "version": "0.3.3",
+      "resolved": "https://registry.npmjs.org/circular-json/-/circular-json-0.3.3.tgz",
+      "integrity": "sha512-UZK3NBx2Mca+b5LsG7bY183pHWt5Y1xts4P3Pz7ENTwGVnJOUWbRb3ocjvX7hx9tq/yTAdclXm9sZ38gNuem4A==",
+      "dev": true
+    },
+    "cli-cursor": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-2.1.0.tgz",
+      "integrity": "sha1-s12sN2R5+sw+lHR9QdDQ9SOP/LU=",
+      "dev": true,
+      "requires": {
+        "restore-cursor": "^2.0.0"
+      }
+    },
+    "cli-width": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/cli-width/-/cli-width-2.2.0.tgz",
+      "integrity": "sha1-/xnt6Kml5XkyQUewwR8PvLq+1jk=",
+      "dev": true
+    },
+    "color-convert": {
+      "version": "1.9.3",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
+      "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
+      "dev": true,
+      "requires": {
+        "color-name": "1.1.3"
+      }
+    },
+    "color-name": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
+      "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
+      "dev": true
+    },
+    "concat-map": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
+      "dev": true
+    },
+    "cross-spawn": {
+      "version": "6.0.5",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-6.0.5.tgz",
+      "integrity": "sha512-eTVLrBSt7fjbDygz805pMnstIs2VTBNkRm0qxZd+M7A5XDdxVRWO5MxGBXZhjY4cqLYLdtrGqRf8mBPmzwSpWQ==",
+      "dev": true,
+      "requires": {
+        "nice-try": "^1.0.4",
+        "path-key": "^2.0.1",
+        "semver": "^5.5.0",
+        "shebang-command": "^1.2.0",
+        "which": "^1.2.9"
+      }
+    },
+    "debug": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
+      "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+      "dev": true,
+      "requires": {
+        "ms": "^2.1.1"
+      }
+    },
+    "deep-is": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz",
+      "integrity": "sha1-s2nW+128E+7PUk+RsHD+7cNXzzQ=",
+      "dev": true
+    },
+    "doctrine": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-2.1.0.tgz",
+      "integrity": "sha512-35mSku4ZXK0vfCuHEDAwt55dg2jNajHZ1odvF+8SSr82EsZY4QmXfuWso8oEd8zRhVObSN18aM0CjSdoBX7zIw==",
+      "dev": true,
+      "requires": {
+        "esutils": "^2.0.2"
+      }
+    },
+    "escape-string-regexp": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+      "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
+      "dev": true
+    },
+    "eslint": {
+      "version": "5.12.0",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-5.12.0.tgz",
+      "integrity": "sha512-LntwyPxtOHrsJdcSwyQKVtHofPHdv+4+mFwEe91r2V13vqpM8yLr7b1sW+Oo/yheOPkWYsYlYJCkzlFAt8KV7g==",
+      "dev": true,
+      "requires": {
+        "@babel/code-frame": "^7.0.0",
+        "ajv": "^6.5.3",
+        "chalk": "^2.1.0",
+        "cross-spawn": "^6.0.5",
+        "debug": "^4.0.1",
+        "doctrine": "^2.1.0",
+        "eslint-scope": "^4.0.0",
+        "eslint-utils": "^1.3.1",
+        "eslint-visitor-keys": "^1.0.0",
+        "espree": "^5.0.0",
+        "esquery": "^1.0.1",
+        "esutils": "^2.0.2",
+        "file-entry-cache": "^2.0.0",
+        "functional-red-black-tree": "^1.0.1",
+        "glob": "^7.1.2",
+        "globals": "^11.7.0",
+        "ignore": "^4.0.6",
+        "import-fresh": "^3.0.0",
+        "imurmurhash": "^0.1.4",
+        "inquirer": "^6.1.0",
+        "js-yaml": "^3.12.0",
+        "json-stable-stringify-without-jsonify": "^1.0.1",
+        "levn": "^0.3.0",
+        "lodash": "^4.17.5",
+        "minimatch": "^3.0.4",
+        "mkdirp": "^0.5.1",
+        "natural-compare": "^1.4.0",
+        "optionator": "^0.8.2",
+        "path-is-inside": "^1.0.2",
+        "pluralize": "^7.0.0",
+        "progress": "^2.0.0",
+        "regexpp": "^2.0.1",
+        "semver": "^5.5.1",
+        "strip-ansi": "^4.0.0",
+        "strip-json-comments": "^2.0.1",
+        "table": "^5.0.2",
+        "text-table": "^0.2.0"
+      }
+    },
+    "eslint-scope": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-4.0.0.tgz",
+      "integrity": "sha512-1G6UTDi7Jc1ELFwnR58HV4fK9OQK4S6N985f166xqXxpjU6plxFISJa2Ba9KCQuFa8RCnj/lSFJbHo7UFDBnUA==",
+      "dev": true,
+      "requires": {
+        "esrecurse": "^4.1.0",
+        "estraverse": "^4.1.1"
+      }
+    },
+    "eslint-utils": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/eslint-utils/-/eslint-utils-1.3.1.tgz",
+      "integrity": "sha512-Z7YjnIldX+2XMcjr7ZkgEsOj/bREONV60qYeB/bjMAqqqZ4zxKyWX+BOUkdmRmA9riiIPVvo5x86m5elviOk0Q==",
+      "dev": true
+    },
+    "eslint-visitor-keys": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-1.0.0.tgz",
+      "integrity": "sha512-qzm/XxIbxm/FHyH341ZrbnMUpe+5Bocte9xkmFMzPMjRaZMcXww+MpBptFvtU+79L362nqiLhekCxCxDPaUMBQ==",
+      "dev": true
+    },
+    "espree": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/espree/-/espree-5.0.0.tgz",
+      "integrity": "sha512-1MpUfwsdS9MMoN7ZXqAr9e9UKdVHDcvrJpyx7mm1WuQlx/ygErEQBzgi5Nh5qBHIoYweprhtMkTCb9GhcAIcsA==",
+      "dev": true,
+      "requires": {
+        "acorn": "^6.0.2",
+        "acorn-jsx": "^5.0.0",
+        "eslint-visitor-keys": "^1.0.0"
+      }
+    },
+    "esprima": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
+      "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
+      "dev": true
+    },
+    "esquery": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.0.1.tgz",
+      "integrity": "sha512-SmiyZ5zIWH9VM+SRUReLS5Q8a7GxtRdxEBVZpm98rJM7Sb+A9DVCndXfkeFUd3byderg+EbDkfnevfCwynWaNA==",
+      "dev": true,
+      "requires": {
+        "estraverse": "^4.0.0"
+      }
+    },
+    "esrecurse": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.2.1.tgz",
+      "integrity": "sha512-64RBB++fIOAXPw3P9cy89qfMlvZEXZkqqJkjqqXIvzP5ezRZjW+lPWjw35UX/3EhUPFYbg5ER4JYgDw4007/DQ==",
+      "dev": true,
+      "requires": {
+        "estraverse": "^4.1.0"
+      }
+    },
+    "estraverse": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.2.0.tgz",
+      "integrity": "sha1-De4/7TH81GlhjOc0IJn8GvoL2xM=",
+      "dev": true
+    },
+    "esutils": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
+      "integrity": "sha1-Cr9PHKpbyx96nYrMbepPqqBLrJs=",
+      "dev": true
+    },
+    "external-editor": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/external-editor/-/external-editor-3.0.3.tgz",
+      "integrity": "sha512-bn71H9+qWoOQKyZDo25mOMVpSmXROAsTJVVVYzrrtol3d4y+AsKjf4Iwl2Q+IuT0kFSQ1qo166UuIwqYq7mGnA==",
+      "dev": true,
+      "requires": {
+        "chardet": "^0.7.0",
+        "iconv-lite": "^0.4.24",
+        "tmp": "^0.0.33"
+      }
+    },
+    "fast-deep-equal": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-2.0.1.tgz",
+      "integrity": "sha1-ewUhjd+WZ79/Nwv3/bLLFf3Qqkk=",
+      "dev": true
+    },
+    "fast-json-stable-stringify": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.0.0.tgz",
+      "integrity": "sha1-1RQsDK7msRifh9OnYREGT4bIu/I=",
+      "dev": true
+    },
+    "fast-levenshtein": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
+      "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=",
+      "dev": true
+    },
+    "figures": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/figures/-/figures-2.0.0.tgz",
+      "integrity": "sha1-OrGi0qYsi/tDGgyUy3l6L84nyWI=",
+      "dev": true,
+      "requires": {
+        "escape-string-regexp": "^1.0.5"
+      }
+    },
+    "file-entry-cache": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-2.0.0.tgz",
+      "integrity": "sha1-w5KZDD5oR4PYOLjISkXYoEhFg2E=",
+      "dev": true,
+      "requires": {
+        "flat-cache": "^1.2.1",
+        "object-assign": "^4.0.1"
+      }
+    },
+    "flat-cache": {
+      "version": "1.3.4",
+      "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-1.3.4.tgz",
+      "integrity": "sha512-VwyB3Lkgacfik2vhqR4uv2rvebqmDvFu4jlN/C1RzWoJEo8I7z4Q404oiqYCkq41mni8EzQnm95emU9seckwtg==",
+      "dev": true,
+      "requires": {
+        "circular-json": "^0.3.1",
+        "graceful-fs": "^4.1.2",
+        "rimraf": "~2.6.2",
+        "write": "^0.2.1"
+      }
+    },
+    "fs.realpath": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+      "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
+      "dev": true
+    },
+    "functional-red-black-tree": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/functional-red-black-tree/-/functional-red-black-tree-1.0.1.tgz",
+      "integrity": "sha1-GwqzvVU7Kg1jmdKcDj6gslIHgyc=",
+      "dev": true
+    },
+    "glob": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.3.tgz",
+      "integrity": "sha512-vcfuiIxogLV4DlGBHIUOwI0IbrJ8HWPc4MU7HzviGeNho/UJDfi6B5p3sHeWIQ0KGIU0Jpxi5ZHxemQfLkkAwQ==",
+      "dev": true,
+      "requires": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.0.4",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
+      }
+    },
+    "globals": {
+      "version": "11.10.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-11.10.0.tgz",
+      "integrity": "sha512-0GZF1RiPKU97IHUO5TORo9w1PwrH/NBPl+fS7oMLdaTRiYmYbwK4NWoZWrAdd0/abG9R2BU+OiwyQpTpE6pdfQ==",
+      "dev": true
+    },
+    "graceful-fs": {
+      "version": "4.1.15",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.15.tgz",
+      "integrity": "sha512-6uHUhOPEBgQ24HM+r6b/QwWfZq+yiFcipKFrOFiBEnWdy5sdzYoi+pJeQaPI5qOLRFqWmAXUPQNsielzdLoecA==",
+      "dev": true
+    },
+    "has-flag": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+      "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+      "dev": true
+    },
+    "iconv-lite": {
+      "version": "0.4.24",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
+      "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
+      "dev": true,
+      "requires": {
+        "safer-buffer": ">= 2.1.2 < 3"
+      }
+    },
+    "ignore": {
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-4.0.6.tgz",
+      "integrity": "sha512-cyFDKrqc/YdcWFniJhzI42+AzS+gNwmUzOSFcRCQYwySuBBBy/KjuxWLZ/FHEH6Moq1NizMOBWyTcv8O4OZIMg==",
+      "dev": true
+    },
+    "import-fresh": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.0.0.tgz",
+      "integrity": "sha512-pOnA9tfM3Uwics+SaBLCNyZZZbK+4PTu0OPZtLlMIrv17EdBoC15S9Kn8ckJ9TZTyKb3ywNE5y1yeDxxGA7nTQ==",
+      "dev": true,
+      "requires": {
+        "parent-module": "^1.0.0",
+        "resolve-from": "^4.0.0"
+      }
+    },
+    "imurmurhash": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
+      "integrity": "sha1-khi5srkoojixPcT7a21XbyMUU+o=",
+      "dev": true
+    },
+    "inflight": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+      "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
+      "dev": true,
+      "requires": {
+        "once": "^1.3.0",
+        "wrappy": "1"
+      }
+    },
+    "inherits": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+      "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
+      "dev": true
+    },
+    "inquirer": {
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-6.2.1.tgz",
+      "integrity": "sha512-088kl3DRT2dLU5riVMKKr1DlImd6X7smDhpXUCkJDCKvTEJeRiXh0G132HG9u5a+6Ylw9plFRY7RuTnwohYSpg==",
+      "dev": true,
+      "requires": {
+        "ansi-escapes": "^3.0.0",
+        "chalk": "^2.0.0",
+        "cli-cursor": "^2.1.0",
+        "cli-width": "^2.0.0",
+        "external-editor": "^3.0.0",
+        "figures": "^2.0.0",
+        "lodash": "^4.17.10",
+        "mute-stream": "0.0.7",
+        "run-async": "^2.2.0",
+        "rxjs": "^6.1.0",
+        "string-width": "^2.1.0",
+        "strip-ansi": "^5.0.0",
+        "through": "^2.3.6"
+      },
+      "dependencies": {
+        "ansi-regex": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.0.0.tgz",
+          "integrity": "sha512-iB5Dda8t/UqpPI/IjsejXu5jOGDrzn41wJyljwPH65VCIbk6+1BzFIMJGFwTNrYXT1CrD+B4l19U7awiQ8rk7w==",
+          "dev": true
+        },
+        "strip-ansi": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.0.0.tgz",
+          "integrity": "sha512-Uu7gQyZI7J7gn5qLn1Np3G9vcYGTVqB+lFTytnDJv83dd8T22aGH451P3jueT2/QemInJDfxHB5Tde5OzgG1Ow==",
+          "dev": true,
+          "requires": {
+            "ansi-regex": "^4.0.0"
+          }
+        }
+      }
+    },
+    "is-fullwidth-code-point": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+      "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
+      "dev": true
+    },
+    "is-promise": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-2.1.0.tgz",
+      "integrity": "sha1-eaKp7OfwlugPNtKy87wWwf9L8/o=",
+      "dev": true
+    },
+    "isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
+      "dev": true
+    },
+    "js-tokens": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
+      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
+      "dev": true
+    },
+    "js-yaml": {
+      "version": "3.12.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.12.1.tgz",
+      "integrity": "sha512-um46hB9wNOKlwkHgiuyEVAybXBjwFUV0Z/RaHJblRd9DXltue9FTYvzCr9ErQrK9Adz5MU4gHWVaNUfdmrC8qA==",
+      "dev": true,
+      "requires": {
+        "argparse": "^1.0.7",
+        "esprima": "^4.0.0"
+      }
+    },
+    "json-schema-traverse": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+      "dev": true
+    },
+    "json-stable-stringify-without-jsonify": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
+      "integrity": "sha1-nbe1lJatPzz+8wp1FC0tkwrXJlE=",
+      "dev": true
+    },
+    "levn": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/levn/-/levn-0.3.0.tgz",
+      "integrity": "sha1-OwmSTt+fCDwEkP3UwLxEIeBHZO4=",
+      "dev": true,
+      "requires": {
+        "prelude-ls": "~1.1.2",
+        "type-check": "~0.3.2"
+      }
+    },
+    "lodash": {
+      "version": "4.17.11",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
+      "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg==",
+      "dev": true
+    },
+    "mimic-fn": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-1.2.0.tgz",
+      "integrity": "sha512-jf84uxzwiuiIVKiOLpfYk7N46TSy8ubTonmneY9vrpHNAnp0QBt2BxWV9dO3/j+BoVAb+a5G6YDPW3M5HOdMWQ==",
+      "dev": true
+    },
+    "minimatch": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+      "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+      "dev": true,
+      "requires": {
+        "brace-expansion": "^1.1.7"
+      }
+    },
+    "minimist": {
+      "version": "0.0.8",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+      "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
+      "dev": true
+    },
+    "mkdirp": {
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+      "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
+      "dev": true,
+      "requires": {
+        "minimist": "0.0.8"
+      }
+    },
+    "ms": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
+      "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg==",
+      "dev": true
+    },
+    "mute-stream": {
+      "version": "0.0.7",
+      "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.7.tgz",
+      "integrity": "sha1-MHXOk7whuPq0PhvE2n6BFe0ee6s=",
+      "dev": true
+    },
+    "natural-compare": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
+      "integrity": "sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc=",
+      "dev": true
+    },
+    "nice-try": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/nice-try/-/nice-try-1.0.5.tgz",
+      "integrity": "sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ==",
+      "dev": true
+    },
+    "object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
+      "dev": true
+    },
+    "once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+      "dev": true,
+      "requires": {
+        "wrappy": "1"
+      }
+    },
+    "onetime": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/onetime/-/onetime-2.0.1.tgz",
+      "integrity": "sha1-BnQoIw/WdEOyeUsiu6UotoZ5YtQ=",
+      "dev": true,
+      "requires": {
+        "mimic-fn": "^1.0.0"
+      }
+    },
+    "optionator": {
+      "version": "0.8.2",
+      "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.8.2.tgz",
+      "integrity": "sha1-NkxeQJ0/TWMB1sC0wFu6UBgK62Q=",
+      "dev": true,
+      "requires": {
+        "deep-is": "~0.1.3",
+        "fast-levenshtein": "~2.0.4",
+        "levn": "~0.3.0",
+        "prelude-ls": "~1.1.2",
+        "type-check": "~0.3.2",
+        "wordwrap": "~1.0.0"
+      }
+    },
+    "os-tmpdir": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
+      "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=",
+      "dev": true
+    },
+    "parent-module": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.0.tgz",
+      "integrity": "sha512-8Mf5juOMmiE4FcmzYc4IaiS9L3+9paz2KOiXzkRviCP6aDmN49Hz6EMWz0lGNp9pX80GvvAuLADtyGfW/Em3TA==",
+      "dev": true,
+      "requires": {
+        "callsites": "^3.0.0"
+      }
+    },
+    "path-is-absolute": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+      "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
+      "dev": true
+    },
+    "path-is-inside": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/path-is-inside/-/path-is-inside-1.0.2.tgz",
+      "integrity": "sha1-NlQX3t5EQw0cEa9hAn+s8HS9/FM=",
+      "dev": true
+    },
+    "path-key": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-2.0.1.tgz",
+      "integrity": "sha1-QRyttXTFoUDTpLGRDUDYDMn0C0A=",
+      "dev": true
+    },
+    "pluralize": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/pluralize/-/pluralize-7.0.0.tgz",
+      "integrity": "sha512-ARhBOdzS3e41FbkW/XWrTEtukqqLoK5+Z/4UeDaLuSW+39JPeFgs4gCGqsrJHVZX0fUrx//4OF0K1CUGwlIFow==",
+      "dev": true
+    },
+    "prelude-ls": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz",
+      "integrity": "sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ=",
+      "dev": true
+    },
+    "progress": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/progress/-/progress-2.0.3.tgz",
+      "integrity": "sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==",
+      "dev": true
+    },
+    "punycode": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
+      "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==",
+      "dev": true
+    },
+    "regexpp": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/regexpp/-/regexpp-2.0.1.tgz",
+      "integrity": "sha512-lv0M6+TkDVniA3aD1Eg0DVpfU/booSu7Eev3TDO/mZKHBfVjgCGTV4t4buppESEYDtkArYFOxTJWv6S5C+iaNw==",
+      "dev": true
+    },
+    "resolve-from": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
+      "integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==",
+      "dev": true
+    },
+    "restore-cursor": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-2.0.0.tgz",
+      "integrity": "sha1-n37ih/gv0ybU/RYpI9YhKe7g368=",
+      "dev": true,
+      "requires": {
+        "onetime": "^2.0.0",
+        "signal-exit": "^3.0.2"
+      }
+    },
+    "rimraf": {
+      "version": "2.6.3",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.3.tgz",
+      "integrity": "sha512-mwqeW5XsA2qAejG46gYdENaxXjx9onRNCfn7L0duuP4hCuTIi/QO7PDK07KJfp1d+izWPrzEJDcSqBa0OZQriA==",
+      "dev": true,
+      "requires": {
+        "glob": "^7.1.3"
+      }
+    },
+    "run-async": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/run-async/-/run-async-2.3.0.tgz",
+      "integrity": "sha1-A3GrSuC91yDUFm19/aZP96RFpsA=",
+      "dev": true,
+      "requires": {
+        "is-promise": "^2.1.0"
+      }
+    },
+    "rxjs": {
+      "version": "6.3.3",
+      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-6.3.3.tgz",
+      "integrity": "sha512-JTWmoY9tWCs7zvIk/CvRjhjGaOd+OVBM987mxFo+OW66cGpdKjZcpmc74ES1sB//7Kl/PAe8+wEakuhG4pcgOw==",
+      "dev": true,
+      "requires": {
+        "tslib": "^1.9.0"
+      }
+    },
+    "safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "dev": true
+    },
+    "sax": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/sax/-/sax-1.2.4.tgz",
+      "integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw==",
+      "dev": true
+    },
+    "semver": {
+      "version": "5.6.0",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-5.6.0.tgz",
+      "integrity": "sha512-RS9R6R35NYgQn++fkDWaOmqGoj4Ek9gGs+DPxNUZKuwE183xjJroKvyo1IzVFeXvUrvmALy6FWD5xrdJT25gMg==",
+      "dev": true
+    },
+    "shebang-command": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-1.2.0.tgz",
+      "integrity": "sha1-RKrGW2lbAzmJaMOfNj/uXer98eo=",
+      "dev": true,
+      "requires": {
+        "shebang-regex": "^1.0.0"
+      }
+    },
+    "shebang-regex": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-1.0.0.tgz",
+      "integrity": "sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM=",
+      "dev": true
+    },
+    "signal-exit": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
+      "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0=",
+      "dev": true
+    },
+    "slice-ansi": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-2.0.0.tgz",
+      "integrity": "sha512-4j2WTWjp3GsZ+AOagyzVbzp4vWGtZ0hEZ/gDY/uTvm6MTxUfTUIsnMIFb1bn8o0RuXiqUw15H1bue8f22Vw2oQ==",
+      "dev": true,
+      "requires": {
+        "ansi-styles": "^3.2.0",
+        "astral-regex": "^1.0.0",
+        "is-fullwidth-code-point": "^2.0.0"
+      }
+    },
+    "sprintf-js": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
+      "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
+      "dev": true
+    },
+    "string-width": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
+      "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
+      "dev": true,
+      "requires": {
+        "is-fullwidth-code-point": "^2.0.0",
+        "strip-ansi": "^4.0.0"
+      }
+    },
+    "strip-ansi": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
+      "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+      "dev": true,
+      "requires": {
+        "ansi-regex": "^3.0.0"
+      }
+    },
+    "strip-json-comments": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
+      "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo=",
+      "dev": true
+    },
+    "supports-color": {
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+      "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+      "dev": true,
+      "requires": {
+        "has-flag": "^3.0.0"
+      }
+    },
+    "table": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/table/-/table-5.2.1.tgz",
+      "integrity": "sha512-qmhNs2GEHNqY5fd2Mo+8N1r2sw/rvTAAvBZTaTx+Y7PHLypqyrxr1MdIu0pLw6Xvl/Gi4ONu/sdceP8vvUjkyA==",
+      "dev": true,
+      "requires": {
+        "ajv": "^6.6.1",
+        "lodash": "^4.17.11",
+        "slice-ansi": "2.0.0",
+        "string-width": "^2.1.1"
+      }
+    },
+    "text-table": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
+      "integrity": "sha1-f17oI66AUgfACvLfSoTsP8+lcLQ=",
+      "dev": true
+    },
+    "through": {
+      "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
+      "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=",
+      "dev": true
+    },
+    "tmp": {
+      "version": "0.0.33",
+      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.33.tgz",
+      "integrity": "sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==",
+      "dev": true,
+      "requires": {
+        "os-tmpdir": "~1.0.2"
+      }
+    },
+    "tslib": {
+      "version": "1.9.3",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.9.3.tgz",
+      "integrity": "sha512-4krF8scpejhaOgqzBEcGM7yDIEfi0/8+8zDRZhNZZ2kjmHJ4hv3zCbQWxoJGz1iw5U0Jl0nma13xzHXcncMavQ==",
+      "dev": true
+    },
+    "type-check": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.3.2.tgz",
+      "integrity": "sha1-WITKtRLPHTVeP7eE8wgEsrUg23I=",
+      "dev": true,
+      "requires": {
+        "prelude-ls": "~1.1.2"
+      }
+    },
+    "uri-js": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.2.2.tgz",
+      "integrity": "sha512-KY9Frmirql91X2Qgjry0Wd4Y+YTdrdZheS8TFwvkbLWf/G5KNJDCh6pKL5OZctEW4+0Baa5idK2ZQuELRwPznQ==",
+      "dev": true,
+      "requires": {
+        "punycode": "^2.1.0"
+      }
+    },
+    "which": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
+      "integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
+      "dev": true,
+      "requires": {
+        "isexe": "^2.0.0"
+      }
+    },
+    "wordwrap": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
+      "integrity": "sha1-J1hIEIkUVqQXHI0CJkQa3pDLyus=",
+      "dev": true
+    },
+    "wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
+      "dev": true
+    },
+    "write": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/write/-/write-0.2.1.tgz",
+      "integrity": "sha1-X8A4KOJkzqP+kUVUdvejxWbLB1c=",
+      "dev": true,
+      "requires": {
+        "mkdirp": "^0.5.1"
+      }
+    },
+    "xml-js": {
+      "version": "1.6.9",
+      "resolved": "https://registry.npmjs.org/xml-js/-/xml-js-1.6.9.tgz",
+      "integrity": "sha512-Omi8lVfq3q3H0xnGcZKLQhoiOghTGN1xxfabah4FybYN1pyvUzh1X+cJ+vKKY3Zr255y1H5IUAT3u3lznshdbw==",
+      "dev": true,
+      "requires": {
+        "sax": "^1.2.4"
+      }
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,33 +1,43 @@
 {
-  "name": "cordova-plugin-image-picker",
+  "name": "@zenput/cordova-plugin-image-picker",
   "version": "1.2.3",
-  "description": "This plugin allows selection of multiple images from the camera roll / gallery in a phonegap app",
+  "description": "Allows selection of multiple images from the camera roll/gallery in a Cordova app",
+  "author": "Zenput",
   "cordova": {
     "id": "cordova-plugin-image-picker",
     "platforms": [
       "ios",
-      "android"
+      "android",
+      "windows"
     ]
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/wymsee/cordova-imagePicker.git"
+    "url": "git+https://github.com/zenput/cordova-plugin-image-picker.git"
   },
   "keywords": [
+    "cordova",
     "ecosystem:cordova",
+    "cordova-android",
     "cordova-ios",
-    "cordova-android"
+    "cordova-windows",
+    "zenput",
+    "images"
   ],
-  "engines": [
-    {
-      "name": "cordova",
-      "version": ">=3.0.0"
-    }
-  ],
-  "author": "Wymsee",
+  "scripts": {
+    "lint": "eslint www/ src/windows/",
+    "lint:fix": "eslint www/ src/windows/ --fix",
+    "preversion": "npm run lint",
+    "version": "node scripts/update-version-num.js $npm_package_version && git add --all .",
+    "postversion": "git push && git push --tags"
+  },
+  "devDependencies": {
+    "eslint": "5.12.0",
+    "xml-js": "1.6.9"
+  },
   "license": "MIT",
   "bugs": {
-    "url": "https://github.com/wymsee/cordova-imagePicker/issues"
+    "url": "https://github.com/zenput/cordova-plugin-image-picker/issues"
   },
-  "homepage": "https://github.com/wymsee/cordova-imagePicker#readme"
+  "homepage": "https://github.com/zenput/cordova-plugin-image-picker#readme"
 }

--- a/plugin.xml
+++ b/plugin.xml
@@ -1,121 +1,93 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<plugin xmlns="http://www.phonegap.com/ns/plugins/1.0"
-  xmlns:android="http://schemas.android.com/apk/res/android"
-  id="cordova-plugin-image-picker"
-  version="1.2.3">
-
-	<dependency id="cordova-plugin-donkeyfont" url="https://github.com/zenput/cordova-plugin-donkeyfont" commit="v1.0.1" />
-	<name>ImagePicker</name>
-	 
-	<description>
-		This plugin allows selection of multiple images from the camera roll / gallery in a phonegap app
+<plugin xmlns="http://www.phonegap.com/ns/plugins/1.0" xmlns:android="http://schemas.android.com/apk/res/android" id="cordova-plugin-image-picker" version="1.2.3">
+    <dependency id="@zenput/cordova-plugin-donkeyfont" version="1.0.1"/>
+    <name>cordova-plugin-donkeyfont</name>
+    <description>
+		Allows selection of multiple images from the camera roll/gallery in a Cordova app
 	</description>
-	
-	<license>MIT</license>
-
-	<engines>
-		<engine name="cordova" version=">=3.0.0" />
-	</engines>  
-
-	<js-module src="www/imagepicker.js" name="ImagePicker">
-		<clobbers target="plugins.imagePicker" />
-	</js-module>
-
+    <license>MIT</license>
+    <engines>
+        <engine name="cordova" version=">=3.0.0"/>
+    </engines>
+    <js-module src="www/imagepicker.js" name="ImagePicker">
+        <clobbers target="plugins.imagePicker"/>
+    </js-module>
     <platform name="windows">
         <js-module src="src/windows/ImagePickerProxy.js" name="ImagePickerProxy">
-            <merges target="" />
+            <merges target=""/>
         </js-module>
     </platform>
-
-	<!-- ios -->
-	<platform name="ios">
-	<preference name="PHOTO_LIBRARY_USAGE_DESCRIPTION" default=" " />
-		<config-file target="*-Info.plist" parent="NSPhotoLibraryUsageDescription">
-			<string>$PHOTO_LIBRARY_USAGE_DESCRIPTION</string>
-		</config-file>
-		<config-file target="config.xml" parent="/*">
-			<feature name="ImagePicker">
-				<param name="ios-package" value="SOSPicker"/>
-			</feature>
-		</config-file>
-
-		<header-file src="src/ios/SOSPicker.h" />
-		<source-file src="src/ios/SOSPicker.m" />
-
-		<header-file src="src/ios/ELCImagePicker/ELCAlbumPickerController.h" />
-		<source-file src="src/ios/ELCImagePicker/ELCAlbumPickerController.m" />
-
-		<header-file src="src/ios/ELCImagePicker/ELCAsset.h" />
-		<source-file src="src/ios/ELCImagePicker/ELCAsset.m" />
-
-		<header-file src="src/ios/ELCImagePicker/ELCAssetCell.h" />
-		<source-file src="src/ios/ELCImagePicker/ELCAssetCell.m" />
-
-		<header-file src="src/ios/ELCImagePicker/ELCAssetPickerFilterDelegate.h" />
-		<header-file src="src/ios/ELCImagePicker/ELCAssetSelectionDelegate.h" />
-
-		<header-file src="src/ios/ELCImagePicker/ELCAssetTablePicker.h" />
-		<source-file src="src/ios/ELCImagePicker/ELCAssetTablePicker.m" />
-
-		<header-file src="src/ios/ELCImagePicker/ELCImagePickerController.h" />
-		<source-file src="src/ios/ELCImagePicker/ELCImagePickerController.m" />
-
-		<resource-file src="src/ios/ELCImagePicker/Resources/ELCAlbumPickerController.xib" />
-		<resource-file src="src/ios/ELCImagePicker/Resources/ELCAssetPicker.xib" />
-		<resource-file src="src/ios/ELCImagePicker/Resources/ELCAssetTablePicker.xib" />
-		<resource-file src="src/ios/ELCImagePicker/Resources/Overlay.png" />
-		<resource-file src="src/ios/ELCImagePicker/Resources/Overlay@2x.png" />
-	</platform>
-
-	<!-- android -->
-	<platform name="android">
-		<config-file target="res/xml/config.xml" parent="/*">
-			<feature name="ImagePicker">
-				<param name="android-package" value="com.synconset.ImagePicker"/>
-			</feature>
-		</config-file>
-		
-		<config-file target="app/src/main/AndroidManifest.xml" parent="/manifest/application">
-		    <activity android:label="@string/multi_app_name" android:name="com.synconset.MultiImageChooserActivity" android:theme="@android:style/Theme.Holo.Light">
-            </activity>
-		</config-file>
-		
-		<config-file target="app/src/main/AndroidManifest.xml" parent="/manifest">
-		    <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
-		</config-file>
-
-		<source-file src="src/android/com/synconset/ImagePicker/ImagePicker.java" target-dir="app/src/main/java/com/synconset" />
-		<source-file src="src/android/com/synconset/ImagePicker/FakeR.java" target-dir="app/src/main/java/com/synconset" />
-		
-		<source-file src="src/android/Library/src/ImageFetcher.java" target-dir="app/src/main/java/com/synconset"/>
-		<source-file src="src/android/Library/src/MultiImageChooserActivity.java" target-dir="app/src/main/java/com/synconset"/>
-		
+    <platform name="ios">
+        <preference name="PHOTO_LIBRARY_USAGE_DESCRIPTION" default=" "/>
+        <config-file target="*-Info.plist" parent="NSPhotoLibraryUsageDescription">
+            <string>$PHOTO_LIBRARY_USAGE_DESCRIPTION</string>
+        </config-file>
+        <config-file target="config.xml" parent="/*">
+            <feature name="ImagePicker">
+                <param name="ios-package" value="SOSPicker"/>
+            </feature>
+        </config-file>
+        <header-file src="src/ios/SOSPicker.h"/>
+        <source-file src="src/ios/SOSPicker.m"/>
+        <header-file src="src/ios/ELCImagePicker/ELCAlbumPickerController.h"/>
+        <source-file src="src/ios/ELCImagePicker/ELCAlbumPickerController.m"/>
+        <header-file src="src/ios/ELCImagePicker/ELCAsset.h"/>
+        <source-file src="src/ios/ELCImagePicker/ELCAsset.m"/>
+        <header-file src="src/ios/ELCImagePicker/ELCAssetCell.h"/>
+        <source-file src="src/ios/ELCImagePicker/ELCAssetCell.m"/>
+        <header-file src="src/ios/ELCImagePicker/ELCAssetPickerFilterDelegate.h"/>
+        <header-file src="src/ios/ELCImagePicker/ELCAssetSelectionDelegate.h"/>
+        <header-file src="src/ios/ELCImagePicker/ELCAssetTablePicker.h"/>
+        <source-file src="src/ios/ELCImagePicker/ELCAssetTablePicker.m"/>
+        <header-file src="src/ios/ELCImagePicker/ELCImagePickerController.h"/>
+        <source-file src="src/ios/ELCImagePicker/ELCImagePickerController.m"/>
+        <resource-file src="src/ios/ELCImagePicker/Resources/ELCAlbumPickerController.xib"/>
+        <resource-file src="src/ios/ELCImagePicker/Resources/ELCAssetPicker.xib"/>
+        <resource-file src="src/ios/ELCImagePicker/Resources/ELCAssetTablePicker.xib"/>
+        <resource-file src="src/ios/ELCImagePicker/Resources/Overlay.png"/>
+        <resource-file src="src/ios/ELCImagePicker/Resources/Overlay@2x.png"/>
+    </platform>
+    <platform name="android">
+        <config-file target="res/xml/config.xml" parent="/*">
+            <feature name="ImagePicker">
+                <param name="android-package" value="com.synconset.ImagePicker"/>
+            </feature>
+        </config-file>
+        <config-file target="app/src/main/AndroidManifest.xml" parent="/manifest/application">
+            <activity android:label="@string/multi_app_name" android:name="com.synconset.MultiImageChooserActivity" android:theme="@android:style/Theme.Holo.Light"/>
+        </config-file>
+        <config-file target="app/src/main/AndroidManifest.xml" parent="/manifest">
+            <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE"/>
+        </config-file>
+        <source-file src="src/android/com/synconset/ImagePicker/ImagePicker.java" target-dir="app/src/main/java/com/synconset"/>
+        <source-file src="src/android/com/synconset/ImagePicker/FakeR.java" target-dir="app/src/main/java/com/synconset"/>
+        <source-file src="src/android/Library/src/ImageFetcher.java" target-dir="app/src/main/java/com/synconset"/>
+        <source-file src="src/android/Library/src/MultiImageChooserActivity.java" target-dir="app/src/main/java/com/synconset"/>
         <source-file src="src/android/Library/res/anim/image_pop_in.xml" target-dir="app/src/main/res/anim"/>
-		<source-file src="src/android/Library/res/drawable/grid_background.xml" target-dir="app/src/main/res/drawable"/>
-		<source-file src="src/android/Library/res/drawable-hdpi/image_bg.9.png" target-dir="app/src/main/res/drawable-hdpi"/>
-		<source-file src="src/android/Library/res/drawable-hdpi/loading_icon.png" target-dir="app/src/main/res/drawable-hdpi"/>
-		<source-file src="src/android/Library/res/drawable-mdpi/ic_action_discard_dark.png" target-dir="app/src/main/res/drawable-mdpi"/>
-		<source-file src="src/android/Library/res/drawable-mdpi/ic_action_discard_light.png" target-dir="app/src/main/res/drawable-mdpi"/>
-		<source-file src="src/android/Library/res/drawable-mdpi/ic_action_done_dark.png" target-dir="app/src/main/res/drawable-mdpi"/>
-		<source-file src="src/android/Library/res/drawable-mdpi/ic_action_done_light.png" target-dir="app/src/main/res/drawable-mdpi"/>
-		<source-file src="src/android/Library/res/drawable-mdpi/ic_launcher.png" target-dir="app/src/main/res/drawable-mdpi"/>
-		<source-file src="src/android/Library/res/drawable-xhdpi/ic_action_discard_dark.png" target-dir="app/src/main/res/drawable-xhdpi"/>
-		<source-file src="src/android/Library/res/drawable-xhdpi/ic_action_discard_light.png" target-dir="app/src/main/res/drawable-xhdpi"/>
-		<source-file src="src/android/Library/res/drawable-xhdpi/ic_action_done_dark.png" target-dir="app/src/main/res/drawable-xhdpi"/>
-		<source-file src="src/android/Library/res/drawable-xhdpi/ic_action_done_light.png" target-dir="app/src/main/res/drawable-xhdpi"/>
-		<source-file src="src/android/Library/res/drawable-xhdpi/ic_launcher.png" target-dir="app/src/main/res/drawable-xhdpi"/>
-		<source-file src="src/android/Library/res/layout/actionbar_custom_view_done_discard.xml" target-dir="app/src/main/res/layout"/>
-		<source-file src="src/android/Library/res/layout/actionbar_discard_button.xml" target-dir="app/src/main/res/layout"/>
-		<source-file src="src/android/Library/res/layout/actionbar_done_button.xml" target-dir="app/src/main/res/layout"/>
-		<source-file src="src/android/Library/res/layout/multiselectorgrid.xml" target-dir="app/src/main/res/layout"/>
-		<source-file src="src/android/Library/res/values/multiimagechooser_strings_en.xml" target-dir="app/src/main/res/values"/>
-		<source-file src="src/android/Library/res/values/themes.xml" target-dir="app/src/main/res/values"/>
-		
-		<source-file src="src/android/Library/res/values-de/multiimagechooser_strings_de.xml" target-dir="app/src/main/res/values-de"/>
-		<source-file src="src/android/Library/res/values-es/multiimagechooser_strings_es.xml" target-dir="app/src/main/res/values-es"/>
-		<source-file src="src/android/Library/res/values-fr/multiimagechooser_strings_fr.xml" target-dir="app/src/main/res/values-fr"/>
-		<source-file src="src/android/Library/res/values-hu/multiimagechooser_strings_hu.xml" target-dir="app/src/main/res/values-hu"/>
-		<source-file src="src/android/Library/res/values-ja/multiimagechooser_strings_ja.xml" target-dir="app/src/main/res/values-ja"/>
-		<source-file src="src/android/Library/res/values-ko/multiimagechooser_strings_ko.xml" target-dir="app/src/main/res/values-ko"/>
-	</platform>
+        <source-file src="src/android/Library/res/drawable/grid_background.xml" target-dir="app/src/main/res/drawable"/>
+        <source-file src="src/android/Library/res/drawable-hdpi/image_bg.9.png" target-dir="app/src/main/res/drawable-hdpi"/>
+        <source-file src="src/android/Library/res/drawable-hdpi/loading_icon.png" target-dir="app/src/main/res/drawable-hdpi"/>
+        <source-file src="src/android/Library/res/drawable-mdpi/ic_action_discard_dark.png" target-dir="app/src/main/res/drawable-mdpi"/>
+        <source-file src="src/android/Library/res/drawable-mdpi/ic_action_discard_light.png" target-dir="app/src/main/res/drawable-mdpi"/>
+        <source-file src="src/android/Library/res/drawable-mdpi/ic_action_done_dark.png" target-dir="app/src/main/res/drawable-mdpi"/>
+        <source-file src="src/android/Library/res/drawable-mdpi/ic_action_done_light.png" target-dir="app/src/main/res/drawable-mdpi"/>
+        <source-file src="src/android/Library/res/drawable-mdpi/ic_launcher.png" target-dir="app/src/main/res/drawable-mdpi"/>
+        <source-file src="src/android/Library/res/drawable-xhdpi/ic_action_discard_dark.png" target-dir="app/src/main/res/drawable-xhdpi"/>
+        <source-file src="src/android/Library/res/drawable-xhdpi/ic_action_discard_light.png" target-dir="app/src/main/res/drawable-xhdpi"/>
+        <source-file src="src/android/Library/res/drawable-xhdpi/ic_action_done_dark.png" target-dir="app/src/main/res/drawable-xhdpi"/>
+        <source-file src="src/android/Library/res/drawable-xhdpi/ic_action_done_light.png" target-dir="app/src/main/res/drawable-xhdpi"/>
+        <source-file src="src/android/Library/res/drawable-xhdpi/ic_launcher.png" target-dir="app/src/main/res/drawable-xhdpi"/>
+        <source-file src="src/android/Library/res/layout/actionbar_custom_view_done_discard.xml" target-dir="app/src/main/res/layout"/>
+        <source-file src="src/android/Library/res/layout/actionbar_discard_button.xml" target-dir="app/src/main/res/layout"/>
+        <source-file src="src/android/Library/res/layout/actionbar_done_button.xml" target-dir="app/src/main/res/layout"/>
+        <source-file src="src/android/Library/res/layout/multiselectorgrid.xml" target-dir="app/src/main/res/layout"/>
+        <source-file src="src/android/Library/res/values/multiimagechooser_strings_en.xml" target-dir="app/src/main/res/values"/>
+        <source-file src="src/android/Library/res/values/themes.xml" target-dir="app/src/main/res/values"/>
+        <source-file src="src/android/Library/res/values-de/multiimagechooser_strings_de.xml" target-dir="app/src/main/res/values-de"/>
+        <source-file src="src/android/Library/res/values-es/multiimagechooser_strings_es.xml" target-dir="app/src/main/res/values-es"/>
+        <source-file src="src/android/Library/res/values-fr/multiimagechooser_strings_fr.xml" target-dir="app/src/main/res/values-fr"/>
+        <source-file src="src/android/Library/res/values-hu/multiimagechooser_strings_hu.xml" target-dir="app/src/main/res/values-hu"/>
+        <source-file src="src/android/Library/res/values-ja/multiimagechooser_strings_ja.xml" target-dir="app/src/main/res/values-ja"/>
+        <source-file src="src/android/Library/res/values-ko/multiimagechooser_strings_ko.xml" target-dir="app/src/main/res/values-ko"/>
+    </platform>
 </plugin>

--- a/scripts/.eslintrc.json
+++ b/scripts/.eslintrc.json
@@ -1,0 +1,9 @@
+{
+    "env": {
+        "es6": true,
+        "node": true
+    },
+    "parserOptions": {
+        "ecmaVersion": 6
+    }
+}

--- a/scripts/update-version-num.js
+++ b/scripts/update-version-num.js
@@ -1,0 +1,26 @@
+/**
+ * This script will update the version number in plugin.xml. This should be called from the `npm version` command,
+ * as per these docs: https://docs.npmjs.com/cli/version.html
+ *
+ * Usage: node update-version-num.js <version number>
+ *
+ */
+
+// @author:david maybe move this to it's own npm package, like @zenput/bump-cordova-plugin-version so we can use this
+// across Cordova plugin projects
+
+const fs = require('fs');
+const convert = require('xml-js');
+
+const newVersion = require('process').argv[2];
+
+if (!newVersion) {
+    console.error('Version not specified');
+    process.exit(1);
+}
+
+const xmlContent = fs.readFileSync('plugin.xml', 'utf8');
+const json = JSON.parse(convert.xml2json(xmlContent, { reversible: true }));
+json.elements.filter(el => el.name === 'plugin')[0].attributes.version = newVersion;
+fs.writeFileSync('plugin.xml', convert.js2xml(json, { spaces: 4 }));
+

--- a/src/windows/.eslintrc.json
+++ b/src/windows/.eslintrc.json
@@ -1,0 +1,14 @@
+{
+    "env": {
+        "es6": true
+    },
+    "parserOptions": {
+        "ecmaVersion": 6
+    },
+    "globals": {
+        "$f": false,
+        "_": false,
+        "Hammer": false,
+        "MediaFile": false
+    }
+}

--- a/src/windows/ImagePickerProxy.js
+++ b/src/windows/ImagePickerProxy.js
@@ -4,8 +4,8 @@ var Imaging = Windows.Graphics.Imaging;
 
 function getPictures(success, error, options) {
     var fileOpenPicker = new Windows.Storage.Pickers.FileOpenPicker();
-    
-    fileOpenPicker.fileTypeFilter.replaceAll([".png", ".jpg", ".jpeg"]);
+
+    fileOpenPicker.fileTypeFilter.replaceAll(['.png', '.jpg', '.jpeg']);
     fileOpenPicker.viewMode = Windows.Storage.Pickers.PickerViewMode.thumbnail;
     fileOpenPicker.suggestedStartLocation = Windows.Storage.Pickers.PickerLocationId.picturesLibrary;
 
@@ -24,12 +24,12 @@ function getPictures(success, error, options) {
             };
         }
     }
-    
-    fileOpenPicker.pickMultipleFilesAsync().then(function (files) {
+
+    fileOpenPicker.pickMultipleFilesAsync().then(function(files) {
         var tempFolder = ApplicationData.current.temporaryFolder;
         var results = [];
 
-        var promises = files.map(function (inputFile) {
+        var promises = files.map(function(inputFile) {
             var outputFile;
             var decoder;
             var detachedPixelData;
@@ -39,35 +39,35 @@ function getPictures(success, error, options) {
             var bitmapProperties = new Imaging.BitmapPropertySet();
             var encoderId;
             var fileType = inputFile.fileType.toUpperCase();
-            if (fileType === ".JPG" ||
-                fileType === ".JPEG") {
+            if (fileType === '.JPG' ||
+                fileType === '.JPEG') {
                 encoderId = Imaging.BitmapEncoder.jpegEncoderId;
                 var compression = Math.min(100, Math.max(0, options.quality));
                 compression = compression / 100.0;
-                bitmapProperties.insert("ImageQuality", new Imaging.BitmapTypedValue(compression, Windows.Foundation.PropertyType.single));
+                bitmapProperties.insert('ImageQuality', new Imaging.BitmapTypedValue(compression, Windows.Foundation.PropertyType.single));
 
-            } else if (fileType === ".PNG") {
+            } else if (fileType === '.PNG') {
                 encoderId = Imaging.BitmapEncoder.pngEncoderId;
             } else {
-                throw 'Invalid filetype'
+                throw new Error('Invalid filetype');
             }
 
-            return inputFile.openAsync(Windows.Storage.FileAccessMode.read).then(function (stream) {
+            return inputFile.openAsync(Windows.Storage.FileAccessMode.read).then(function(stream) {
                 inputStream = stream;
                 return tempFolder.createFileAsync('tmpImage' + fileType, Windows.Storage.CreationCollisionOption.generateUniqueName);
-            }.bind(this)).then(function (file) {
+            }.bind(this)).then(function(file) {
                 outputFile = file;
                 return outputFile.openAsync(Windows.Storage.FileAccessMode.readWrite);
-            }).then(function (output) {
+            }).then(function(output) {
                 outputStream = output;
                 return Imaging.BitmapDecoder.createAsync(inputStream);
-            }.bind(this)).then(function (bitmapDecoder) {
+            }.bind(this)).then(function(bitmapDecoder) {
                 decoder = bitmapDecoder;
                 return decoder.getPixelDataAsync();
-            }.bind(this)).then(function (pixelData) {
+            }.bind(this)).then(function(pixelData) {
                 detachedPixelData = pixelData.detachPixelData();
                 return Imaging.BitmapEncoder.createAsync(encoderId, outputStream, bitmapProperties);
-            }.bind(this)).then(function (encoder) {
+            }.bind(this)).then(function(encoder) {
                 encoder.setPixelData(
                     decoder.bitmapPixelFormat, decoder.bitmapAlphaMode,
                     decoder.orientedPixelWidth, decoder.orientedPixelHeight, decoder.dpiX, decoder.dpiY,
@@ -81,26 +81,26 @@ function getPictures(success, error, options) {
                 encoder.bitmapTransform.scaledHeight = scaledSize.height;
 
                 return encoder.flushAsync();
-            }.bind(this)).then(function () {
+            }.bind(this)).then(function() {
                 results.push('ms-appdata:///temp/' + outputFile.name);
 
-            }, function (err) {
+            }, function(err) {
                 error();
             });
         });
-            
-        return Promise.all(promises).then(function () {
+
+        return Promise.all(promises).then(function() {
             success(results);
-        } , error);
-            
+        }, error);
+
     }, error);
 }
 
-ImagePicker = {
-    getPictures: function (success, error, params) {
+var ImagePicker = {
+    getPictures: function(success, error, params) {
         var options = params[0];
         getPictures(success, error, options);
     }
 };
 
-require("cordova/exec/proxy").add("ImagePicker", ImagePicker);
+require('cordova/exec/proxy').add('ImagePicker', ImagePicker);

--- a/www/imagepicker.js
+++ b/www/imagepicker.js
@@ -1,7 +1,7 @@
-/*global cordova,window,console*/
+/* global cordova,window,console*/
 /**
  * An Image Picker plugin for Cordova
- * 
+ *
  * Developed by Wymsee for Sync OnSet
  */
 
@@ -13,7 +13,7 @@ var ImagePicker = function() {
 *	success - success callback
 *	fail - error callback
 *	options
-*		.maximumImagesCount - max images to be selected, defaults to 15. If this is set to 1, 
+*		.maximumImagesCount - max images to be selected, defaults to 15. If this is set to 1,
 *		                      upon selection of a single image, the plugin will return it.
 *		.width - width to resize image to (if one of height/width is 0, will resize to fit the
 *		         other while keeping aspect ratio, if both height and width are 0, the full size
@@ -22,18 +22,18 @@ var ImagePicker = function() {
 *		.quality - quality of resized image, defaults to 100
 */
 ImagePicker.prototype.getPictures = function(success, fail, options) {
-	if (!options) {
-		options = {};
-	}
-	
-	var params = {
-		maximumImagesCount: options.maximumImagesCount ? options.maximumImagesCount : 15,
-		width: options.width ? options.width : 0,
-		height: options.height ? options.height : 0,
-		quality: options.quality ? options.quality : 100
-	};
+    if (!options) {
+        options = {};
+    }
 
-	return cordova.exec(success, fail, "ImagePicker", "getPictures", [params]);
+    var params = {
+        maximumImagesCount: options.maximumImagesCount ? options.maximumImagesCount : 15,
+        width: options.width ? options.width : 0,
+        height: options.height ? options.height : 0,
+        quality: options.quality ? options.quality : 100
+    };
+
+    return cordova.exec(success, fail, 'ImagePicker', 'getPictures', [params]);
 };
 
 window.imagePicker = new ImagePicker();


### PR DESCRIPTION
This updates the tooling around this plugin to support Javascript linting and deployment to `npm`.

## Linting

This implements `eslint` using mostly the same rules we use for our core Javascript app. (This is mostly important for Windows, since this plugin is written in JS for Windows.)

**To run the linter:**

```sh
npm run lint
```

**To auto-fix linting errors:**

```sh
npm run lint:fix
```

## Deployment

For both our own Cordova plugins as well as those we've forked, we're loading them by tag or hash from Github in our `package.json`. While this works, it is not as performant and fine-tuned as loading packages from a proper NPM registry. This is likely the reason that `scripts/buildphonegap.sh --reinstall-all` takes so long. ([See this article for more](https://blog.npmjs.org/post/154387331670/the-right-tool-for-the-job-why-not-to-use-version).)

Now that we have an organization on NPM for our internal React projects, we can begin migrating our Cordova plugins and hopefully speed up our build times. This will be a helpful improvement when we get mobile builds on CI for testing, continuous deployment, etc.

Here is the workflow for releasing updates to this plugin (and other plugins we update for NPM deployment):

1. Merge all relevant branches into `master`.
1. From `master`, tag the release version with:
    ```sh
    npm version <version number>
    ```
    This will:
    
    - Update the version number in `package.json`
    - Update the version number in `plugin.xml`
    - Commit this change via `git` and create a Git tag for the release
    - Push these changes to Github
1. Deploy the update to `npm`:
    ```sh
    npm publish
    ```
1. Detail the release on the releases page (as we already do).
1. In the consuming project (i.e., Zenput Mobile), install the plugin update with:
    ```sh
    cordova plugin add @zenput/cordova-plugin-image-picker@latest
    ```

## Opportunities for Future Improvement

In the future, we can improve this workflow with the following:

- Implement CI to ensure code linting is in the green before we try to version/deploy. (`npm version` will already fail if linting fails.)
- Implement further Cordova unit and functional testing, which we can wire into the release process and CI.
- Move `scripts/update-version-num.js` (which updates `plugin.xml` with the new version number) to a separate npm package that each of our Cordova plugins can consume. For now, I'm just copying this script to each project that needs it.
- Automatically deploy to NPM from CI once code is merged into `master` and the version is updated.

## Feedback

Please let me know what should be modified, fixed, or improved, or if anything doesn't make sense.