### PR TITLE
[ZP-8706] Support Cordova 11

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Allows selection of multiple images from the camera roll/gallery in a Cordova app",
   "author": "Zenput",
   "cordova": {
-    "id": "cordova-plugin-image-picker",
+    "id": "@zenput/cordova-plugin-image-picker",
     "platforms": [
       "ios",
       "android",

--- a/plugin.xml
+++ b/plugin.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<plugin xmlns="http://www.phonegap.com/ns/plugins/1.0" xmlns:android="http://schemas.android.com/apk/res/android" id="cordova-plugin-image-picker" version="21.5.20-H10M15S50">
+<plugin xmlns="http://www.phonegap.com/ns/plugins/1.0" xmlns:android="http://schemas.android.com/apk/res/android" id="@zenput/cordova-plugin-image-picker" version="21.5.20-H10M15S50">
     <dependency id="cordova-plugin-donkeyfont" version="1.0.1"/>
-    <name>cordova-plugin-donkeyfont</name>
+    <name>@zenput/cordova-plugin-image-picker</name>
     <description>
 		Allows selection of multiple images from the camera roll/gallery in a Cordova app
 	</description>


### PR DESCRIPTION
This update brings support for Cordova 11 by using the `@zenput/` scoping everywhere.

⚠️ Before Merging:

- [x] Merge and publish the Donkeyfont update: https://github.com/zenput/cordova-plugin-donkeyfont/pull/4
- [x] Refer to the new Donkeyfont version here
- [x] Run `npm run calversion` and `npm publish` here.